### PR TITLE
Bugfix for the gating mechanism + update imports

### DIFF
--- a/iamondb.py
+++ b/iamondb.py
@@ -1,9 +1,11 @@
+import warnings
 import matplotlib as mpl
 import matplotlib.pyplot as plt
 import numpy as np
 import scipy.signal
 import theano.tensor as T
 
+from numpy.lib.stride_tricks import as_strided
 from iamondb_utils import fetch_iamondb
 
 def tolist(arg):
@@ -502,7 +504,7 @@ class IAMOnDB(TemporalSeries, SequentialPrepMixin):
 
         if self.prep == 'normalize':
             X = new_x
-            print X[0].shape
+            print(X[0].shape)
         elif self.prep == 'standardize':
             X, self.X_max, self.X_min = self.standardize(raw_X)
 
@@ -567,7 +569,7 @@ if __name__ == "__main__":
         min_x = np.min(item[:,1])
         min_y = np.min(item[:,2])
 
-    print np.max(max_x)
-    print np.max(max_y)
-    print np.min(min_x)
-    print np.min(min_y)
+    print((np.max(max_x)))
+    print((np.max(max_y)))
+    print((np.min(min_x)))
+    print((np.min(min_y)))

--- a/load.py
+++ b/load.py
@@ -1,6 +1,6 @@
 import numpy as np
 import numpy.random as npr
-from scipy.io import loadmat
+# from scipy.io import loadmat
 import os
 import json
 from collections import defaultdict, OrderedDict
@@ -162,7 +162,6 @@ class IAMOnDBIterator(object):
             #print(x_batch.shape);
             mask_batch = mask_batch[1:];
             yield x_batch, y_batch, mask_batch
-from motion_utils import read_bvh
 
 class DanceIterator(object):
     def __init__(self, dance_folder, fnames, seq_len, is_test = False, X_mean = None, X_std = None, ab = False):
@@ -191,6 +190,7 @@ class DanceIterator(object):
         return dances    
     
     def batchify_(self, dances, is_test=False, mean = None, std = None):
+        from motion_utils import read_bvh
         seq_len = self.seq_len;
         dance_batch=[];
         mask_batch = []

--- a/models/rnn.py
+++ b/models/rnn.py
@@ -1,8 +1,10 @@
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-from Regressor import Regressor
-from utils import *;
+
+from models.Regressor import Regressor
+from models.utils import LogLikelihood
+
 
 class Model(nn.Module):
     def __init__(self, input_dim, embed_dim, output_dim, data=None):

--- a/models/swavenet.py
+++ b/models/swavenet.py
@@ -1,8 +1,10 @@
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-from Regressor import Regressor
-from utils import *;
+from torch.autograd import Variable
+
+from models.Regressor import Regressor
+from models.utils import gaussian_kld, LogLikelihood
 
 
 class WaveNetGate(nn.Module):
@@ -37,7 +39,7 @@ class WaveNetGate(nn.Module):
             tanh_x = self.filter_conv_bn(tanh_x); 
             if self.residual_link:
                 residual_x = self.residual_bn(residual_x);
-        sigomid_x = F.sigmoid(sigmoid_x);
+        sigmoid_x = F.sigmoid(sigmoid_x);
         tanh_x = F.tanh(tanh_x);
         x = tanh_x * sigmoid_x;
         #print(x.size(), residual_x.size());
@@ -205,7 +207,9 @@ class Model(nn.Module):
             
             #compute KL(q||p)
             tmp = gaussian_kld([mu, theta], [z_mu, z_theta]);
+            # print (tmp.shape, mask.shape)
             tmp = tmp.permute(2,0,1);
+            # print (tmp.shape)
             tmp = (tmp.sum(-1) * mask).sum(0);
             tmp = tmp.mean();
             kld_loss += tmp;

--- a/models/swavenet_hw.py
+++ b/models/swavenet_hw.py
@@ -56,7 +56,7 @@ class WaveNetGate(nn.Module):
             tanh_x = self.filter_conv_bn(tanh_x); 
             if self.residual_link:
                 residual_x = self.residual_bn(residual_x);
-        sigomid_x = F.sigmoid(sigmoid_x);
+        sigmoid_x = F.sigmoid(sigmoid_x);
         tanh_x = F.tanh(tanh_x);
         x = tanh_x * sigmoid_x;
         if (self.residual_link):

--- a/models/wavenet.py
+++ b/models/wavenet.py
@@ -1,8 +1,9 @@
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-from Regressor import Regressor
-from utils import *;
+
+from models.Regressor import Regressor
+from models.utils import LogLikelihood
 
 
 class Model(nn.Module):
@@ -77,7 +78,7 @@ class Model(nn.Module):
                 tanh_x = self.filter_conv_bns[i](tanh_x); 
                 residual_x = self.residual_bns[i](residual_x);
                 
-            sigomid_x = F.sigmoid(sigmoid_x);
+            sigmoid_x = F.sigmoid(sigmoid_x);
             tanh_x = F.tanh(tanh_x);
             
             x = tanh_x * sigmoid_x;


### PR DESCRIPTION
I came across a typo in the implementation of wavenet and stochastic wavenet gating mechanism. Originally wavenet uses a GTU: ```tanh(x)*sigm(x)```, however in the code the gating is ``x*tanh(x)``. Haven't tested it but likely this explains some of the instability encountered during training. 
A bugfix and fixes of missing imports (+updated pytorch definitions) are in this pull request. Either way, cool work.